### PR TITLE
add rake tasks for initializing database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 
 before_script:
   - source script/xvfb_source.bash
+  - bundle exec rake db:init
 
 script:
   - bash script/run_server.bash

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,15 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 gem 'activerecord'
-group(:development, :test) { gem 'sqlite3' }
-group(:production) { gem 'pg' }
+
+if dburl = ENV['DATABASE_URL']
+  case URI.parse(dburl).scheme
+  when 'mysql'; gem 'mysql2'
+  when 'postgres'; gem 'pg'
+  end
+else
+  gem 'sqlite3'
+end
 
 gem 'slim'
 gem 'sass'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 
 ruby '2.3.1'
 
+gem 'rake'
+
 gem 'puma'
 gem 'sinatra'
 gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rake (11.2.2)
     sass (3.4.22)
     sinatra (1.4.7)
       rack (~> 1.5)
@@ -60,11 +61,15 @@ DEPENDENCIES
   coffee-script
   pg
   puma
+  rake
   sass
   sinatra
   sinatra-contrib
   slim
   sqlite3
+
+RUBY VERSION
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,6 @@ GEM
     slim (3.0.7)
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
-    sqlite3 (1.3.11)
     temple (0.7.7)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -66,10 +65,9 @@ DEPENDENCIES
   sinatra
   sinatra-contrib
   slim
-  sqlite3
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,65 @@
+require_relative 'db'
+
+namespace :db do
+  task :init => [:reset, :seed]
+
+  task :reset => ['reset:all']
+  namespace :reset do
+    task :all => [:drop_tables, :create_tables]
+    
+    task :drop_tables do
+      ActiveRecord::Base.logger = Logger.new(STDERR)
+      con = ActiveRecord::Base.connection
+      con.tables.each {|t| con.drop_table(t) }
+    end
+
+    task :create_tables do
+      ActiveRecord::Schema.define do
+        create_table :apps do |t|
+          t.string :name
+          t.belongs_to :user
+        end
+
+        create_table :devices do |t|
+          t.string :name
+          t.string :board
+          t.string :status
+        end
+
+        create_table :users do |t|
+          t.string :login_id
+          t.string :name
+        end
+      end
+    end
+  end
+
+  task :seed => 'seed:all'
+  namespace :seed do
+    task :all => [:users, :devices]
+
+    task :users do
+      User.create(login_id: 'bob', name: 'Bob') { |u| u.apps.new(name: 'oh-my-app') }
+      User.create(login_id: 'alice', name: 'Alice')
+      User.create(login_id: 'merry', name: 'Merry') { |u| u.apps.new(name: 'awesome-iot-app') }
+      User.create(login_id: 'myuser', name: 'My User') do |u|
+        [
+          { :name => 'plus-one-button', },
+          { :name => 'plus-one-counter', },
+          { :name => 'my-first-app', },
+          { :name => 'another-app', },
+          { :name => 'awesome-app', },
+          { :name => 'example-app', },
+        ].each { |a| u.apps.new(a) }
+      end
+    end
+
+    task :devices do
+      [
+        { name: 'my-home-rpi3', board: 'rpi3', status: 'running' },
+        { name: 'my-lab-rpi3', board: 'rpi3', status: 'down' },
+        { name: 'mitoh-esp8266', board: 'esp8266', status: 'ready' },
+      ].each { |d| Device.create(d) }
+    end
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -2,21 +2,15 @@ require 'sinatra'
 require 'slim'
 require 'sass'
 require 'json'
-if development?
-  require 'sinatra/reloader'
-end
+require 'sinatra/reloader' if development?
 
-# setup database
 require_relative 'db'
-
-# load apps
 require_relative 'app/base'
 require_relative 'app/codestand_io'
 require_relative 'app/auth'
 require_relative 'app/mgmt'
 require_relative 'app/debug_app'
 
-# routes
 map('/') { run CodestandIO }
 map('/auth') { run Auth }
 map('/mgmt') { run Mgmt }

--- a/db.rb
+++ b/db.rb
@@ -1,50 +1,16 @@
+# db.rb is used by config.ru and rake tasks (e.g., db:reset, db:seed)
 require 'active_record'
 require 'yaml'
 require 'erb'
 
-if ENV['RACK_ENV'] == 'development'
-  ActiveRecord::Base.logger = Logger.new(STDERR)
+ActiveRecord::Base.logger = Logger.new(STDERR) unless ENV['RACK_ENV'] == 'production'
+
+conf = if dburl = ENV['DATABASE_URL']
+  { 'url' => dburl, 'pool' => 16 }
+else
+  { 'adapter' => 'sqlite3', 'database' => 'db/db.sqlite3', 'pool' => 16 }
 end
-
-# config
-conf = YAML.load <<EOF
-development:
-  adapter: sqlite3
-  database: db/development
-test:
-  adapter: sqlite3
-  database: db/test
-EOF
-conf['production'] = {
-  'url' => ENV['DATABASE_URL'],
-  'pool' => '16',
-}
-
-# connect database
-env_conf = conf[ENV['RACK_ENV'] || 'development']
-ActiveRecord::Base.establish_connection(env_conf)
-
-# reset
-con = ActiveRecord::Base.connection
-con.tables.each {|t| con.drop_table(t) }
-
-ActiveRecord::Schema.define do
-  create_table :apps do |t|
-    t.string :name
-    t.belongs_to :user
-  end
-
-  create_table :devices do |t|
-    t.string :name
-    t.string :board
-    t.string :status
-  end
-
-  create_table :users do |t|
-    t.string :login_id
-    t.string :name
-  end
-end
+ActiveRecord::Base.establish_connection(conf)
 
 class App < ActiveRecord::Base
 end
@@ -55,23 +21,3 @@ end
 class User < ActiveRecord::Base
   has_many :apps
 end
-
-User.create(login_id: 'bob', name: 'Bob').apps.create(name: 'oh-my-app')
-User.create(login_id: 'alice', name: 'Alice')
-User.create(login_id: 'merry', name: 'Merry').apps.create(name: 'awesome-iot-app')
-
-myuser = User.create(login_id: 'myuser', name: 'My User')
-DEFAULT_APPS = [
-  { :name => 'plus-one-button', },
-  { :name => 'plus-one-counter', },
-  { :name => 'my-first-app', },
-  { :name => 'another-app', },
-  { :name => 'awesome-app', },
-  { :name => 'example-app', },
-].each { |a| myuser.apps.create(a) }
-
-DEFAULT_DEVCIES = [
-  { name: 'my-home-rpi3', board: 'rpi3', status: 'running' },
-  { name: 'my-lab-rpi3', board: 'rpi3', status: 'down' },
-  { name: 'mitoh-esp8266', board: 'esp8266', status: 'ready' },
-].each { |d| Device.create(d) }


### PR DESCRIPTION
This is to divide resetting and seeding database from `db.rb`. // but, in the near future, we should go to drop all database operations from mockup. ;-)

* `db:init`: Call db:reset => db:seed
* `db:reset`: Drop and create tables
* `db:seed`: Setup dummy data

Thanks.